### PR TITLE
Fix issue when actions not hide

### DIFF
--- a/Example/MailExample.xcodeproj/project.pbxproj
+++ b/Example/MailExample.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		290FF0C72823EBC200212EAE /* RoundedCornersActionContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */; };
 		290FF0C92823EC6000212EAE /* UIColor+Highlighted.swift in Sources */ = {isa = PBXBuildFile; fileRef = 290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */; };
 		291D91482835380B00FCA894 /* MailExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 291D91472835380B00FCA894 /* MailExampleUITests.swift */; };
+		296D458C28A3DA2B0002C5B5 /* ListPagesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 296D458B28A3DA2B0002C5B5 /* ListPagesViewController.swift */; };
 		29FC1CF62822AD2A00F48AA8 /* CustomMailCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */; };
 		3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B041E44AC2600E22A38 /* AppDelegate.swift */; };
 		3F234B0B1E44AC2600E22A38 /* MailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B051E44AC2600E22A38 /* MailTableViewController.swift */; };
@@ -54,6 +55,7 @@
 		290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Highlighted.swift"; sourceTree = "<group>"; };
 		291D91452835380B00FCA894 /* MailExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MailExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		291D91472835380B00FCA894 /* MailExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailExampleUITests.swift; sourceTree = "<group>"; };
+		296D458B28A3DA2B0002C5B5 /* ListPagesViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListPagesViewController.swift; sourceTree = "<group>"; };
 		29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomMailCollectionViewController.swift; sourceTree = "<group>"; };
 		3F234AE31E44AA5E00E22A38 /* MailExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MailExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3F234AF21E44AA5E00E22A38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -137,6 +139,7 @@
 				3F234B051E44AC2600E22A38 /* MailTableViewController.swift */,
 				B93ECA9C1EDEF1EA00AE05AD /* MailCollectionViewController.swift */,
 				29FC1CF52822AD2A00F48AA8 /* CustomMailCollectionViewController.swift */,
+				296D458B28A3DA2B0002C5B5 /* ListPagesViewController.swift */,
 				290FF0C62823EBC200212EAE /* RoundedCornersActionContentView.swift */,
 				290FF0C82823EC6000212EAE /* UIColor+Highlighted.swift */,
 				B93ECA9E1EDEF56300AE05AD /* Shared.swift */,
@@ -276,6 +279,7 @@
 				290FF0C72823EBC200212EAE /* RoundedCornersActionContentView.swift in Sources */,
 				29FC1CF62822AD2A00F48AA8 /* CustomMailCollectionViewController.swift in Sources */,
 				B93ECA9F1EDEF56300AE05AD /* Shared.swift in Sources */,
+				296D458C28A3DA2B0002C5B5 /* ListPagesViewController.swift in Sources */,
 				3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */,
 				3F234B0C1E44AC2600E22A38 /* Data.swift in Sources */,
 				290FF0C92823EC6000212EAE /* UIColor+Highlighted.swift in Sources */,

--- a/Example/MailExample/CustomMailCollectionViewController.swift
+++ b/Example/MailExample/CustomMailCollectionViewController.swift
@@ -16,11 +16,25 @@ class CustomMailCollectionViewController: UICollectionViewController, UICollecti
     var buttonDisplayMode: ButtonDisplayMode = .titleAndImage
     var buttonStyle: ButtonStyle = .backgroundColor
     var usesTallCells = false
-    
+    private let isManualMode: Bool
+
+    init() {
+        isManualMode = true
+        super.init(collectionViewLayout: UICollectionViewFlowLayout())
+    }
+
+    required init?(coder: NSCoder) {
+        isManualMode = false
+        super.init(coder: coder)
+    }
+
     // MARK: - Lifecycle
     
     override func viewDidLoad() {
         navigationItem.rightBarButtonItem = editButtonItem
+        if isManualMode {
+            collectionView.register(CustomMailCollectionViewCell.self, forCellWithReuseIdentifier: "MailCell")
+        }
         
         resetData()
     }
@@ -38,6 +52,9 @@ class CustomMailCollectionViewController: UICollectionViewController, UICollecti
         let email = emails[indexPath.row]
         
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MailCell", for: indexPath) as! CustomMailCollectionViewCell
+        if isManualMode {
+            cell.setupViews()
+        }
         
         cell.delegate = self
         cell.selectedBackgroundView = UIView()
@@ -232,7 +249,57 @@ class CustomMailCollectionViewCell: SwipeCollectionViewCell {
             indicatorView.transform = unread ? CGAffineTransform.identity : CGAffineTransform.init(scaleX: 0.001, y: 0.001)
         }
     }
-    
+
+    func setupViews() {
+        fromLabel = UILabel()
+        fromLabel.font = .preferredFont(forTextStyle: .headline)
+        fromLabel.textColor = .label
+        dateLabel = UILabel()
+        dateLabel.font = .preferredFont(forTextStyle: .subheadline)
+        dateLabel.textColor = .secondaryLabel
+        subjectLabel = UILabel()
+        subjectLabel.font = .preferredFont(forTextStyle: .subheadline)
+        subjectLabel.textColor = .label
+        bodyLabel = UILabel()
+        bodyLabel.font = .preferredFont(forTextStyle: .subheadline)
+        bodyLabel.textColor = .secondaryLabel
+
+        let hStack = UIStackView(arrangedSubviews: [
+            fromLabel,
+            dateLabel,
+            UIImageView(image: UIImage(named: "Disclosure")!)
+        ])
+        hStack.axis = .horizontal
+        hStack.spacing = 6
+
+        let vStack = UIStackView(arrangedSubviews: [
+            hStack,
+            subjectLabel,
+            bodyLabel
+        ])
+        vStack.axis = .vertical
+        vStack.spacing = 2
+
+        contentView.addSubview(vStack)
+        let separator = UIView()
+        separator.backgroundColor = .separator
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(separator)
+
+        vStack.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            vStack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            vStack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+            vStack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 4),
+            vStack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: 4),
+            separator.leadingAnchor.constraint(equalTo: vStack.leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            separator.heightAnchor.constraint(equalToConstant: 0.5)
+        ])
+
+        setupIndicatorView()
+    }
+
     override func awakeFromNib() {
         setupIndicatorView()
     }

--- a/Example/MailExample/ListPagesViewController.swift
+++ b/Example/MailExample/ListPagesViewController.swift
@@ -1,0 +1,157 @@
+//
+//  ListPagesViewController.swift
+//  MailExample
+//
+//  Created by Ilia Sedov on 10.08.2022.
+//
+
+import Foundation
+import UIKit
+
+final class ListPagesViewController: UIViewController {
+    private var pagesDataSource: PagesDataSource!
+    private var pagesViewController: UIPageViewController!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        pagesDataSource = .init()
+        pagesViewController = createPagesViewController()
+
+        addChild(pagesViewController)
+        pagesViewController.view.embedTo(parentView: view)
+        pagesViewController.didMove(toParent: self)
+
+        navigationItem.rightBarButtonItems = [
+            UIBarButtonItem(
+                barButtonSystemItem: .fastForward,
+                target: self,
+                action: #selector(showNext)
+            ),
+            UIBarButtonItem(
+                barButtonSystemItem: .rewind,
+                target: self,
+                action: #selector(showPrev)
+            )
+        ]
+    }
+
+    @objc
+    private func showPrev() {
+        guard let currentController = pagesViewController.viewControllers?.first,
+              let nextController = pagesDataSource.pageViewController(
+                pagesViewController,
+                viewControllerBefore: currentController
+              )
+        else { return }
+
+        pagesViewController.setViewControllers(
+            [nextController],
+            direction: .reverse,
+            animated: true,
+            completion: nil
+        )
+    }
+
+    @objc
+    private func showNext() {
+        guard let currentController = pagesViewController.viewControllers?.first,
+              let nextController = pagesDataSource.pageViewController(
+                pagesViewController,
+                viewControllerAfter: currentController
+              )
+        else { return }
+
+        pagesViewController.setViewControllers(
+            [nextController],
+            direction: .forward,
+            animated: true,
+            completion: nil
+        )
+    }
+
+    private func createPagesViewController() -> UIPageViewController {
+        let pagesController = UIPageViewController(
+            transitionStyle: .scroll,
+            navigationOrientation: .horizontal,
+            options: [.interPageSpacing: 16]
+        )
+        pagesController.dataSource = pagesDataSource
+        pagesController
+            .setViewControllers(
+                [pagesDataSource.initialController],
+                direction: .forward,
+                animated: false,
+                completion: nil
+            )
+        return pagesController
+    }
+}
+
+class PagesDataSource: NSObject, UIPageViewControllerDataSource {
+    private let controllers: [UIViewController]
+
+    private static func isListController(_ viewController: UIViewController) -> Bool {
+        viewController is CustomMailCollectionViewController
+    }
+
+    private static func getListContentController() -> UIViewController {
+        CustomMailCollectionViewController()
+    }
+
+    private static func getDummyController() -> UIViewController {
+        let controller = UIViewController()
+        controller.view.backgroundColor = .purple
+        let caption = UILabel()
+        caption.font = .preferredFont(forTextStyle: .caption1)
+        caption.text = "Dummy"
+        caption.textColor = .white
+        caption.backgroundColor = .clear
+        caption.embedTo(parentView: controller.view)
+        return controller
+    }
+
+    override init() {
+        controllers = [
+            Self.getListContentController(),
+            Self.getDummyController()
+        ]
+    }
+
+    var initialController: UIViewController {
+        controllers.first!
+    }
+
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        viewControllerBefore viewController: UIViewController
+    ) -> UIViewController? {
+        if Self.isListController(viewController) {
+            return nil
+        }
+        return controllers.first
+    }
+
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        viewControllerAfter viewController: UIViewController
+    ) -> UIViewController? {
+        if Self.isListController(viewController) {
+            return controllers.last
+        }
+        return nil
+    }
+}
+
+
+extension UIView {
+    func embedTo(parentView: UIView) {
+        parentView.addSubview(self)
+        translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            leadingAnchor.constraint(equalTo: parentView.leadingAnchor),
+            trailingAnchor.constraint(equalTo: parentView.trailingAnchor),
+            topAnchor.constraint(equalTo: parentView.safeAreaLayoutGuide.topAnchor),
+            bottomAnchor.constraint(equalTo: parentView.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+}

--- a/Example/MailExample/Main.storyboard
+++ b/Example/MailExample/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LX8-Wu-PZs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LX8-Wu-PZs">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -170,7 +170,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <sections>
-                            <tableViewSection id="iR0-38-MTh">
+                            <tableViewSection headerTitle="Basic examples" id="iR0-38-MTh">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="rW1-t9-nrA" style="IBUITableViewCellStyleDefault" id="Kgd-u6-cy7">
                                         <rect key="frame" x="0.0" y="44.666666030883789" width="414" height="44"/>
@@ -230,6 +230,30 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <segue destination="L77-gb-JYx" kind="show" id="HlL-CN-ByY"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Exotic examples" id="8p9-CA-7lH">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="Fhl-FV-g7e" style="IBUITableViewCellStyleDefault" id="T9v-M6-dDN">
+                                        <rect key="frame" x="0.0" y="243.99999809265137" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="T9v-M6-dDN" id="5sX-v0-Bmq">
+                                            <rect key="frame" x="0.0" y="0.0" width="385.33333333333331" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Lists in pages controller" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Fhl-FV-g7e">
+                                                    <rect key="frame" x="20" y="0.0" width="357.33333333333331" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="Fwa-tU-csS" kind="show" id="8iB-Kb-enZ"/>
                                         </connections>
                                     </tableViewCell>
                                 </cells>
@@ -364,7 +388,26 @@
                 </collectionViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zfN-Wd-L2x" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1615.9420289855075" y="606.52173913043487"/>
+            <point key="canvasLocation" x="1690" y="543"/>
+        </scene>
+        <!--List Pages View Controller-->
+        <scene sceneID="5xC-sh-fNL">
+            <objects>
+                <viewController id="Fwa-tU-csS" customClass="ListPagesViewController" customModule="MailExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="cSI-OU-mye"/>
+                        <viewControllerLayoutGuide type="bottom" id="3fp-jo-f5H"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="SLN-MJ-u01">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="UDo-Wv-mgZ"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="QSr-NV-5mq" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2540" y="1162"/>
         </scene>
         <!--Inbox-->
         <scene sceneID="rc3-hV-i2y">

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -193,6 +193,7 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
     func reset() {
         contentView.clipsToBounds = false
         swipeController.reset()
+        swipeController.resetSwipe()
         collectionView?.setGestureEnabled(true)
     }
     

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -360,6 +360,8 @@ class SwipeController: NSObject {
         
         swipeable?.actionsView?.removeFromSuperview()
         swipeable?.actionsView = nil
+
+        actionsContainerView?.mask = nil
     }
     
 }
@@ -582,9 +584,11 @@ extension SwipeController: SwipeActionsViewDelegate {
         
         if animated {
             animate(toOffset: targetCenter) { complete in
+                swipeable.state = targetState
                 completion?(complete)
             }
         } else {
+            swipeable.state = targetState
             actionsContainerView.center.x = targetCenter
             swipeable.actionsView?.visibleWidth = abs(actionsContainerView.frame.minX)
         }


### PR DESCRIPTION
At some context of usage, for example, switching between pages in `UIPageViewController` swipe actions not hide properly.
This PR fixes it:
- do proper reset and cleanup of swipe-cell state
- better track cell state after animations
- add example to reproduce page controller case

Fix addresses this bug:

https://user-images.githubusercontent.com/1941619/184322251-b558d396-6dfc-491c-9cb3-1a9868c9052e.mov

