### PR TITLE
Fix swipe actions collapsing on collection view cell content updates

### DIFF
--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -96,6 +96,20 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
         swipeController.delegate = self
     }
     
+    // Preserve contentView's horizontal offset during layout passes (e.g. reconfigureItems).
+    // contentView is pinned to cell edges via Auto Layout, so super.layoutSubviews() resets
+    // contentView.center.x — collapsing an open swipe even though state is still active.
+    /// :nodoc:
+    override open func layoutSubviews() {
+        if state.isActive {
+            let contentCenterX = contentView.center.x
+            super.layoutSubviews()
+            contentView.center.x = contentCenterX
+        } else {
+            super.layoutSubviews()
+        }
+    }
+
     /// :nodoc:
     override open func prepareForReuse() {
         super.prepareForReuse()


### PR DESCRIPTION
When `reconfigureItems` (or any content update) triggers a layout pass on a `SwipeCollectionViewCell` with an active swipe, Auto Layout resets `contentView.center.x` back to center — visually collapsing the revealed swipe actions even though state remains .left/.right.

**Root cause:** `SwipeCollectionViewCell` uses `contentView` as its `actionsContainerView`, and `contentView` is pinned to the cell edges via Auto Layout constraints. When `super.layoutSubviews()` resolves constraints, it snaps `contentView` back.

**Fix:** Override `layoutSubviews()` to save and restore `contentView.center.x` when the swipe state is active.

Notes:
1. Upstream repository is not supported from 2019 (last accepted PR) so we can only fix in our fork.